### PR TITLE
fix: make python3 complient

### DIFF
--- a/bookmark_generator.py
+++ b/bookmark_generator.py
@@ -38,7 +38,7 @@ parser.add_argument('-t', '--tag', help="add a tag to all bookmarks")
 parser.add_argument("inputfile", help="the bookmark input file")
 args = parser.parse_args()
 
-bookmark_data = yaml.load(open(args.inputfile))
+bookmark_data = yaml.safe_load(open(args.inputfile))
 
 out = sys.stdout
 


### PR DESCRIPTION
yaml.load is deprecated, so safe_load is used instead

still works the same